### PR TITLE
Fix for not showing system alert

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -343,6 +343,24 @@ EarlGrey.select(elementWithMatcher:matcher)
                   assertWithMatcher:grey_notNil()];
 ```
 
+**How do I dismiss system alerts, like being asked to allow push notifications?**
+Include a launch argument for testing, that doesn't register your app for notifications.
+
+Something like:
+
+```if [[[NSProcessInfo processInfo] arguments] containsObject:argument] {
+     return;
+    }
+```
+
+before you call
+
+```[[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+   [[UIApplication sharedApplication] registerForRemoteNotifications];
+```
+
+This way, the "Do you want to allow push notifications..." alert won't show.
+
 **How do I wait for an element to appear using Swift?**
 
 The best way is to [setup synchronization](features.md#synchronization) so that EarlGrey automatically waits


### PR DESCRIPTION
A quick fix for not registering the app for notifications. This way, the system alert to allow push notifications won't show. I'm not sure if this would work for camera access, or location services.